### PR TITLE
Detect `&apos;` and replace it with ’

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-app-copy",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-app-copy",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-app-copy",
-  "version": "0.0.4",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-app-copy",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-app-copy",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "An ESLint plugin to enforce Geckoboard's in-house style guide for application copy",
   "main": "index.js",
   "repository": {

--- a/src/prefer-rsquo.js
+++ b/src/prefer-rsquo.js
@@ -1,4 +1,4 @@
-const aposRegex = /(\w)'(\w)/g;
+const aposRegex = /(\w)(?:'|&apos;)(\w)/g;
 
 function detectApos(context, node, str) {
   if (str.match(aposRegex)) {
@@ -6,7 +6,7 @@ function detectApos(context, node, str) {
       node,
       message: `Prefer right single quote (’) over apostrophes (')`,
       fix: (fixer) => {
-        const replacement = str.replaceAll(aposRegex, '$1’$2');
+        const replacement = str.replaceAll(aposRegex, "$1’$2");
         return fixer.replaceText(node, replacement);
       },
     });

--- a/tests/prefer-rsquo.test.js
+++ b/tests/prefer-rsquo.test.js
@@ -14,6 +14,7 @@ ruleTester.run("prefer-quot rule", rule, {
   valid: [
     { code: `const good = "Don’t"` },
     { code: `const good = "And then he said: 'hello'"` },
+    { code: `"I&rsquo;ve used an HTML entity here, which is fine as well"` },
     { code: `<span>I’m just some regular text</span>` },
   ],
   invalid: [
@@ -25,6 +26,11 @@ ruleTester.run("prefer-quot rule", rule, {
     {
       code: "const bad = `Won't`",
       output: "const bad = `Won’t`",
+      errors: 1,
+    },
+    {
+      code: `const bad = "can&apos;t use the wrong HTML entity as a workaround"`,
+      output: `const bad = "can’t use the wrong HTML entity as a workaround"`,
       errors: 1,
     },
     {
@@ -45,6 +51,11 @@ ruleTester.run("prefer-quot rule", rule, {
     {
       code: `<span>You're welcome</span>`,
       output: `<span>You’re welcome</span>`,
+      errors: 1,
+    },
+    {
+      code: `<span>You won&apos;t get away with it</span>`,
+      output: `<span>You won’t get away with it</span>`,
       errors: 1,
     },
     {


### PR DESCRIPTION
It's currently possible to evade the `prefer-rsquo` linter by using `&apos;` instead of `'`, but we should treat them both the same.