### PR TITLE
Adds new lint rules for `en-dash`, `em-dash` and `hyphen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Within your `.eslintrc` file you'll need to add this plugin to the plugins secti
     plugins: ['app-copy'],
     rules: {
         'app-copy/no-apologies': 'warn',
-        'app-copy/prefer-quot': 'error',
+        'app-copy/prefer-rsquo': 'error',
+        'app-copy/use-em-dash': 'error',
+        'app-copy/use-en-dash': 'error',
+        'app-copy/use-hyphen': 'error',
     }
 }
 ```
@@ -55,4 +58,54 @@ const templateString = `Matt’s cat is ${name}`;
 const MyComponent = () => (<span>That's Leo's mug!</span>);
 const stringLiteral = "You don't have permission to do that!";
 const templateString = `Matt's cat is ${name}`;
+```
+
+### use-em-dash
+
+This rule encourages the use of an em-dash (—) for parenthetical breaks between words, rather than a hyphen (-) or en-dash (–). This rule is **auto fixable**.
+
+#### valid
+```
+const stringLiteral = "A good — dash";
+const MyComponent = () => (<span>A good — dash in JSX</span>);
+```
+
+#### invalid
+```
+const stringLiteral = "A bad - hyphen";
+const stringLiteral = "A bad – endash";
+const stringLiteral = "no double -- dashes";
+```
+
+### use-en-dash
+
+This rule encourages the use of an en-dash (–) for numeric ranges, with no surrounding spaces, rather than a hyphen (-) or em-dash (—). This rule is **auto fixable**.
+
+#### valid
+```
+const stringLiteral = "A good 0–9 endash";
+const MyComponent = () => (<span>A good 0–9 endash in JSX</span>);
+```
+
+#### invalid
+```
+const stringLiteral = "A hyphen 0-9";
+const stringLiteral = "An emdash 0—9";
+const stringLiteral = "Correct dash but spaces 0 - 9";
+```
+
+### use-hyphen
+
+This rule encourages the use of a hyphen (-) for compound words, rather than an en-dash (–) or em-dash (—). This rule is **auto fixable**.
+
+#### valid
+```
+const stringLiteral = "A good-hyphen";
+const MyComponent = () => (<span>A good-hyphen</span>);
+```
+
+#### invalid
+```
+const stringLiteral = "A bad–endash";
+const stringLiteral = "A bad—emdash";
 ```

--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
 const NoApologies = require("./src/no-apologies");
 const PreferRsquo = require("./src/prefer-rsquo");
+const UseEMDash = require("./src/use-em-dash");
+const UseENDash = require("./src/use-en-dash");
+const UseHyphen = require("./src/use-hyphen");
 
 module.exports = {
   rules: {
     "no-apologies": NoApologies,
     "prefer-rsquo": PreferRsquo,
+    "use-em-dash": UseEMDash,
+    "use-en-dash": UseENDash,
+    "use-hyphen": UseHyphen,
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-app-copy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "An ESLint plugin to enforce Geckoboard's in-house style guide for application copy",
   "main": "index.js",
   "repository": {

--- a/src/use-em-dash.js
+++ b/src/use-em-dash.js
@@ -1,0 +1,52 @@
+const enDashRegex = /(\w*\s)(?:–|&ndash;)(\s\w*)/g;
+const hyphenRegex = /(\w*\s)(?:--?-?|&hyphen;)(\s\w*)/g;
+
+function detectDash(context, node, str) {
+  // Check for incorrect en-dash
+  if (str.match(enDashRegex)) {
+    context.report({
+      node,
+      message: `Prefer em-dash (—) over en-dash (–)`,
+      fix: (fixer) => {
+        const replacement = str.replaceAll(enDashRegex, "$1—$2");
+        return fixer.replaceText(node, replacement);
+      }
+    })
+  }
+
+  // Check for incorrect hyphen
+  if (str.match(hyphenRegex)) {
+    context.report({
+      node,
+      message: `Prefer em-dash (—) over hyphen (-)`,
+      fix: (fixer) => {
+        const replacement = str.replaceAll(hyphenRegex, "$1—$2");
+        return fixer.replaceText(node, replacement);
+      }
+    })
+  }
+}
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Detect cases where an &mdash; (—) should be used instead of a &hyphen; (-) or &ndash; (–)",
+    },
+    fixable: "code",
+  },
+  create: (context) => {
+    return {
+      Literal: (node) => {
+        detectDash(context, node, node.raw);
+      },
+      JSXText: (node) => {
+        detectDash(context, node, node.raw);
+      },
+      TemplateElement: (node) => {
+        // See https://github.com/eslint/eslint/issues/16061.
+        detectDash(context, node, context.getSourceCode().getText(node));
+      },
+    }
+  }
+}

--- a/src/use-em-dash.js
+++ b/src/use-em-dash.js
@@ -1,5 +1,5 @@
-const enDashRegex = /(\w*\s)(?:–|&ndash;)(\s\w*)/g;
-const hyphenRegex = /(\w*\s)(?:--?-?|&hyphen;)(\s\w*)/g;
+const enDashRegex = /([a-zA-Z]+\s)(?:–|&ndash;)(\s[a-zA-Z]+)/g;
+const hyphenRegex = /([a-zA-Z]+\s)(?:--?-?|&hyphen;)(\s[a-zA-Z]+)/g;
 
 function detectDash(context, node, str) {
   // Check for incorrect en-dash

--- a/src/use-em-dash.js
+++ b/src/use-em-dash.js
@@ -1,5 +1,5 @@
 const enDashRegex = /([a-zA-Z]+\s)(?:–|&ndash;)(\s[a-zA-Z]+)/g;
-const hyphenRegex = /([a-zA-Z]+\s)(?:--?-?|&hyphen;)(\s[a-zA-Z]+)/g;
+const hyphenRegex = /([a-zA-Z]+\s)(?:-{1,3}|&hyphen;)(\s[a-zA-Z]+)/g;
 
 function detectDash(context, node, str) {
   // Check for incorrect en-dash

--- a/src/use-en-dash.js
+++ b/src/use-en-dash.js
@@ -7,7 +7,7 @@ function detectDash(context, node, str) {
   if (str.match(emDashRegex)) {
     context.report({
       node,
-      message: `Prefer en-dash (–) over em-dash (—) for ranges`,
+      message: `Prefer en-dash (–) over em-dash (—) for numeric ranges`,
       fix: (fixer) => {
         const replacement = str.replaceAll(emDashRegex, "$1–$2");
         return fixer.replaceText(node, replacement);
@@ -19,7 +19,7 @@ function detectDash(context, node, str) {
   if (str.match(hyphenRegex)) {
     context.report({
       node,
-      message: `Prefer en-dash (–) over hyphen (-) for ranges`,
+      message: `Prefer en-dash (–) over hyphen (-) for numeric ranges`,
       fix: (fixer) => {
         const replacement = str.replaceAll(hyphenRegex, "$1–$2");
         return fixer.replaceText(node, replacement);
@@ -31,7 +31,7 @@ function detectDash(context, node, str) {
   if (str.match(enDashSpacesRegex)) {
     context.report({
       node,
-      message: `Removes spaces around en-dash (–) for ranges`,
+      message: `Removes spaces around en-dash (–) for numeric ranges`,
       fix: (fixer) => {
         const replacement = str.replaceAll(enDashSpacesRegex, "$1–$2");
         return fixer.replaceText(node, replacement);

--- a/src/use-en-dash.js
+++ b/src/use-en-dash.js
@@ -1,0 +1,65 @@
+const hyphenRegex = /(\d+)\s?(?:-|&hyphen;)\s?(\d+)/g;
+const emDashRegex = /(\d+)\s?(?:—|&mdash;)\s?(\d+)/g;
+const enDashSpacesRegex = /(\d+)\s(?:–|&ndash;)\s(\d+)/g;
+
+function detectDash(context, node, str) {
+  // Check for incorrect em-dash
+  if (str.match(emDashRegex)) {
+    context.report({
+      node,
+      message: `Prefer en-dash (–) over em-dash (—) for ranges`,
+      fix: (fixer) => {
+        const replacement = str.replaceAll(emDashRegex, "$1–$2");
+        return fixer.replaceText(node, replacement);
+      }
+    })
+  }
+
+  // Check for incorrect hyphen
+  if (str.match(hyphenRegex)) {
+    context.report({
+      node,
+      message: `Prefer en-dash (–) over hyphen (-) for ranges`,
+      fix: (fixer) => {
+        const replacement = str.replaceAll(hyphenRegex, "$1–$2");
+        return fixer.replaceText(node, replacement);
+      }
+    })
+  }
+
+  // Check for spaces
+  if (str.match(enDashSpacesRegex)) {
+    context.report({
+      node,
+      message: `Removes spaces around en-dash (–) for ranges`,
+      fix: (fixer) => {
+        const replacement = str.replaceAll(enDashSpacesRegex, "$1–$2");
+        return fixer.replaceText(node, replacement);
+      }
+    })
+  }
+}
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Detect cases where an &ndash; (–) should be used instead of a &mdash; (—) or &hyphen; (-)",
+    },
+    fixable: "code",
+  },
+  create: (context) => {
+    return {
+      Literal: (node) => {
+        detectDash(context, node, node.raw);
+      },
+      JSXText: (node) => {
+        detectDash(context, node, node.raw);
+      },
+      TemplateElement: (node) => {
+        // See https://github.com/eslint/eslint/issues/16061.
+        detectDash(context, node, context.getSourceCode().getText(node));
+      },
+    }
+  }
+}

--- a/src/use-hyphen.js
+++ b/src/use-hyphen.js
@@ -1,0 +1,52 @@
+const enDashRegex = /(\w*)(?:–|&ndash;)(\w*)/g;
+const emDashRegex = /(\w*)(?:—|&mdash;)(\w*)/g;
+
+function detectDash(context, node, str) {
+  // Check for incorrect en-dash
+  if (str.match(enDashRegex)) {
+    context.report({
+      node,
+      message: `Prefer hyphen (-) over en-dash (–) for composite words`,
+      fix: (fixer) => {
+        const replacement = str.replaceAll(enDashRegex, "$1-$2");
+        return fixer.replaceText(node, replacement);
+      }
+    })
+  }
+
+  // Check for incorrect hyphen
+  if (str.match(emDashRegex)) {
+    context.report({
+      node,
+      message: `Prefer  hyphen (-) over em-dash (—) for composite words`,
+      fix: (fixer) => {
+        const replacement = str.replaceAll(emDashRegex, "$1-$2");
+        return fixer.replaceText(node, replacement);
+      }
+    })
+  }
+}
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Detect cases where an &hyphen; (-) should be used instead of a &mdash; (—) or &ndash; (–)",
+    },
+    fixable: "code",
+  },
+  create: (context) => {
+    return {
+      Literal: (node) => {
+        detectDash(context, node, node.raw);
+      },
+      JSXText: (node) => {
+        detectDash(context, node, node.raw);
+      },
+      TemplateElement: (node) => {
+        // See https://github.com/eslint/eslint/issues/16061.
+        detectDash(context, node, context.getSourceCode().getText(node));
+      },
+    }
+  }
+}

--- a/src/use-hyphen.js
+++ b/src/use-hyphen.js
@@ -1,5 +1,5 @@
-const enDashRegex = /(\w*)(?:–|&ndash;)(\w*)/g;
-const emDashRegex = /(\w*)(?:—|&mdash;)(\w*)/g;
+const enDashRegex = /([a-zA-Z]+)(?:–|&ndash;)([a-zA-Z]+)/g;
+const emDashRegex = /([a-zA-Z]+)(?:—|&mdash;)([a-zA-Z]+)/g;
 
 function detectDash(context, node, str) {
   // Check for incorrect en-dash
@@ -14,7 +14,7 @@ function detectDash(context, node, str) {
     })
   }
 
-  // Check for incorrect hyphen
+  // Check for incorrect em-dash
   if (str.match(emDashRegex)) {
     context.report({
       node,

--- a/tests/use-em-dash.test.js
+++ b/tests/use-em-dash.test.js
@@ -22,6 +22,7 @@ ruleTester.run("use-em-dash rule", rule, {
     { code: `<span>A good — dash in JSX</span>` },
     { code: `"A mid-word hyphen is ok!"` },
     { code: `"A numerical 0–9 range is also ok!"` },
+    { code: `"A numerical range with spaces 0 – 9"` },
   ],
   invalid: [
     {

--- a/tests/use-em-dash.test.js
+++ b/tests/use-em-dash.test.js
@@ -1,0 +1,63 @@
+const RuleTester = require("eslint").RuleTester;
+const rule = require("../src/use-em-dash");
+
+// Useful for copying and pasting
+// em-dash: —
+// en-dash: –
+// hyphen: -
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run("use-em-dash rule", rule, {
+  valid: [
+    { code: `"A good — dash"` },
+    { code: `"An encoded &mdash; dash"` },
+    { code: `<span>A good — dash in JSX</span>` },
+    { code: `"A mid-word hyphen is ok!"` },
+    { code: `"A numerical 0–9 range is also ok!"` },
+  ],
+  invalid: [
+    {
+      code: `"A bad - hyphen"`,
+      output: `"A bad — hyphen"`,
+      errors: 1,
+    },
+    {
+      code: `<span>A bad - hyphen in JSX</span>`,
+      output: `<span>A bad — hyphen in JSX</span>`,
+      errors: 1,
+    },
+    {
+      code: `"A bad encoded &hyphen; hyphen"`,
+      output: `"A bad encoded — hyphen"`,
+      errors: 1,
+    },
+    {
+      code: `"A bad – endash"`,
+      output: `"A bad — endash"`,
+      errors: 1,
+    },
+    {
+      code: `"A bad encoded &ndash; endash"`,
+      output: `"A bad encoded — endash"`,
+      errors: 1,
+    },
+    {
+      code: `"no double -- dashes"`,
+      output: `"no double — dashes"`,
+      errors: 1,
+    },
+    {
+      code: `"no triple --- dashes"`,
+      output: `"no triple — dashes"`,
+      errors: 1,
+    }
+  ]
+});

--- a/tests/use-en-dash.test.js
+++ b/tests/use-en-dash.test.js
@@ -1,0 +1,56 @@
+const RuleTester = require("eslint").RuleTester;
+const rule = require("../src/use-en-dash");
+
+// Useful for copying and pasting
+// em-dash: —
+// en-dash: –
+// hyphen: -
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run("use-en-dash rule", rule, {
+  valid: [
+    { code: `"A good 0–9 endash"` },
+    { code: `<span>A good 0–9 endash in JSX</span>` },
+    { code: `"A good encoded 0&ndash;9 endash"` },
+  ],
+  invalid: [
+    {
+      code: `"A hyphen 0-9"`,
+      output: `"A hyphen 0–9"`,
+      errors: 1,
+    },
+    {
+      code: `"An emdash 0—9"`,
+      output: `"An emdash 0–9"`,
+      errors: 1,
+    },
+    {
+      code: `"Correct dash but spaces 0 - 9"`,
+      output: `"Correct dash but spaces 0–9"`,
+      errors: 1,
+    },
+    {
+      code: `<span>A hyphen in JSX 0-9</span>`,
+      output: `<span>A hyphen in JSX 0–9</span>`,
+      errors: 1,
+    },
+    {
+      code: `"A bad encoded 0&mdash;9 emdash"`,
+      output: `"A bad encoded 0–9 emdash"`,
+      errors: 1,
+    },
+    {
+      code: `"A bad encoded 0&hyphen;9 hyphen"`,
+      output: `"A bad encoded 0–9 hyphen"`,
+      errors: 1,
+    },
+  ]
+});

--- a/tests/use-hyphen.test.js
+++ b/tests/use-hyphen.test.js
@@ -1,0 +1,51 @@
+const RuleTester = require("eslint").RuleTester;
+const rule = require("../src/use-hyphen");
+
+// Useful for copying and pasting
+// em-dash: —
+// en-dash: –
+// hyphen: -
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run("use-hyphen rule", rule, {
+  valid: [
+    { code: `"A good-hyphen"` },
+    { code: `<span>A good-hyphen</span>` },
+    { code: `"An good encoded&hyphen;"` },
+  ],
+  invalid: [
+    {
+      code: `"A bad–endash"`,
+      output: `"A bad-endash"`,
+      errors: 1,
+    },
+    {
+      code: `"A bad—emdash"`,
+      output: `"A bad-emdash"`,
+      errors: 1,
+    },
+    {
+      code: `<span>A bad—emdash in JSX</span>`,
+      output: `<span>A bad-emdash in JSX</span>`,
+      errors: 1,
+    },
+    {
+      code: `"A bad encoded&ndash;endash"`,
+      output: `"A bad encoded-endash"`,
+      errors: 1,
+    },
+    {
+      code: `"A bad encoded&mdash;emdash"`,
+      output: `"A bad encoded-emdash"`,
+      errors: 1,
+    },
+  ]
+});


### PR DESCRIPTION
I think this should catch most cases, we can disable or come back and fix for any exceptions later.

See https://geckoboard.slack.com/archives/C05DWK8Q0F2/p1777555829998439